### PR TITLE
Polish the code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ serial_test = "0.4.0"
 version = "1"
 default-features = false
 features = ["user-hooks"]
-
-[features]
-elf64 = []

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -180,20 +180,20 @@ fn fix_exit_ecall(graph: &mut ControlFlowGraph) {
 fn build(binary: &[u8]) -> ControlFlowGraph {
     let mut graph = create_instruction_graph(binary);
 
-    fn add_edges(graph: &mut ControlFlowGraph, edges: Vec<Edge>) {
+    fn add_edges(graph: &mut ControlFlowGraph, edges: &[Edge]) {
         edges.iter().for_each(|e| {
             graph.add_edge(e.0, e.1, e.2);
         });
     }
 
     let edges = compute_edges(&graph, construct_edge_if_trivial);
-    add_edges(&mut graph, edges);
+    add_edges(&mut graph, &edges);
 
     let pure_edges = compute_edges(&graph, construct_edge_if_pure);
-    add_edges(&mut graph, pure_edges);
+    add_edges(&mut graph, &pure_edges);
 
     let jump_edges = compute_stateful_edges(&graph);
-    add_edges(&mut graph, jump_edges);
+    add_edges(&mut graph, &jump_edges);
 
     fix_exit_ecall(&mut graph);
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 //! # Decode risc-v instructions
 
-use riscv_decode::types::*;
+use riscv_decode::types::{BType, IType, JType, RType, SType, UType};
 use riscv_decode::{decode, Instruction};
 
 pub trait RiscU: Sized + 'static {
@@ -31,8 +31,8 @@ impl<R: RiscU> Decoder<'_, R> {
 }
 impl<R: RiscU> Decoder<'_, R> {
     pub fn run(&mut self, instruction: u32) {
-        match decode(instruction) {
-            Ok(instr) => match instr {
+        if let Ok(instr) = decode(instruction) {
+            match instr {
                 Instruction::Lui(i) => self.next.lui(i),
                 Instruction::Addi(i) => self.next.addi(i),
                 Instruction::Add(i) => self.next.add(i),
@@ -47,9 +47,10 @@ impl<R: RiscU> Decoder<'_, R> {
                 Instruction::Jalr(i) => self.next.jalr(i),
                 Instruction::Beq(i) => self.next.beq(i),
                 Instruction::Ecall => self.next.ecall(),
-                _ => unimplemented!(),
-            },
-            _ => unimplemented!(),
+                i => unimplemented!("instruction: {:?}", i),
+            }
+        } else {
+            unimplemented!()
         }
     }
 }

--- a/src/disassemble.rs
+++ b/src/disassemble.rs
@@ -2,7 +2,7 @@
 
 use crate::elf::load_file;
 use byteorder::{ByteOrder, LittleEndian};
-use riscv_decode::types::*;
+use riscv_decode::types::{BType, IType, JType, RType, SType, UType};
 use std::path::Path;
 
 use crate::decode::{Decoder, RiscU};

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2,7 +2,8 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use goblin::elf::{
-    header::header64::Header, program_header::program_header64::ProgramHeader, program_header::*,
+    header::header64::Header, program_header::program_header64::ProgramHeader,
+    program_header::PT_LOAD,
 };
 use std::fs;
 use std::path::Path;
@@ -125,7 +126,7 @@ pub unsafe fn load(image: &[u8], memory_limit: usize) -> Option<(Vec<u8>, Vec<u8
     // TODO: this does only work for RISCU binaries
     let code_length = match image.chunks(8).nth(15) {
         Some(chunk) => LittleEndian::read_u64(chunk),
-        None => 0u64,
+        None => 0_u64,
     };
 
     println!("memory.len(): {}", memory.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,15 +109,15 @@ fn main() {
 
                 // println!("{:?}", path);
 
-                let (formula, _root) = build_dataflow_graph(
+                let (formula, root) = build_dataflow_graph(
                     &path,
                     data_segment.as_slice(),
-                    elf_metadata,
+                    &elf_metadata,
                     branch_decisions,
                 )
                 .unwrap();
 
-                let graph_wo_dc = eliminate_dead_code(&formula, _root);
+                let graph_wo_dc = eliminate_dead_code(&formula, root);
 
                 let dot_graph = Dot::with_config(&graph_wo_dc, &[]);
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -240,8 +240,8 @@ fn value(
             }
         }
         Node::Constraint(c) => {
-            if is_constraint_invertable(c.op.clone(), x, s, t, side) {
-                compute_inverse_constraint_value(c.op.clone(), x, s, t, side)
+            if is_constraint_invertable(c.op, x, s, t, side) {
+                compute_inverse_constraint_value(c.op, x, s, t, side)
             // TODO: Compute consistent value and choose between inverse and consistent
             // non-deterministiclly
             //let consistent = compute_consistent_value()
@@ -267,9 +267,7 @@ fn is_essential(
 
     match &formula[other] {
         Node::Instruction(i) => !is_invertable(i.instruction, at_ns, ab_nx, t, on_side.other()),
-        Node::Constraint(c) => {
-            !is_constraint_invertable(c.op.clone(), at_ns, ab_nx, t, on_side.other())
-        }
+        Node::Constraint(c) => !is_constraint_invertable(c.op, at_ns, ab_nx, t, on_side.other()),
         // TODO: not mentioned in paper => improvised. is that really true?
         Node::Constant(_) => true,
         // TODO: not mentioned in paper => improvised. is that really true?


### PR DESCRIPTION
- Remove unused cargo feature.
- Use `&[Edge]` instead of `Vec<Edge>`.
- Use `if let` instead of `match` at `decode.rs:31`.
- Instead of `use ...::*` explicitly import used modules.
- Use reference to `ElfMetadata`.
- Use from trait when casting `utype` to `u64`.
- Use `0_u64` instead of `0u64`.
- Remove `_` prefix for variables which are used.
- Remove unneeded `clone()`.