### PR TITLE
Update to clap 3.0.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
  "atty",
  "bitflags",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -286,9 +286,9 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -299,14 +299,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -452,17 +450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Monster is a symbolic execution engine for 64-bit RISC-V code"
 [dependencies]
 goblin = "0.2"
 byteorder = "1.3.4"
-clap = "3.0.0-beta.1"
+clap = "3.0.0-beta.2"
 riscv-decode = { git = "https://github.com/cksystemsgroup/riscv-decode" }
 petgraph = "0.5.1"
 rand = "0.7.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,16 +3,13 @@ use clap::{crate_authors, crate_description, crate_name, crate_version, App, App
 pub fn args() -> App<'static> {
     App::new(crate_name!())
         .version(crate_version!())
-        .author(
-            // Fixed in future release of clap:
-            crate_authors!(), //.replace(":", ", ").as_str()
-        )
+        .author(crate_authors!(", "))
         .about(crate_description!())
         .subcommand(
             App::new("disassemble")
                 .about("Disassemble a RISC-V ELF binary")
                 .arg(
-                    Arg::with_name("input-file")
+                    Arg::new("input-file")
                         .short('c')
                         .long("disassemble")
                         .value_name("FILE")
@@ -25,7 +22,7 @@ pub fn args() -> App<'static> {
             App::new("compile")
                 .about("Compile source files to RISC-V ELF binaries")
                 .arg(
-                    Arg::with_name("input-file")
+                    Arg::new("input-file")
                         .about("Source file to be compiled")
                         .short('c')
                         .long("input-file")
@@ -34,7 +31,7 @@ pub fn args() -> App<'static> {
                         .required(true),
                 )
                 .arg(
-                    Arg::with_name("compiler")
+                    Arg::new("compiler")
                         .about("Compiler to be used")
                         .short('k')
                         .long("compiler")
@@ -48,7 +45,7 @@ pub fn args() -> App<'static> {
             App::new("cfg")
                 .about("Generate control flow graph from RISC-U ELF binary")
                 .arg(
-                    Arg::with_name("input-file")
+                    Arg::new("input-file")
                         .about("Source RISC-U binary to be analyzed")
                         .short('c')
                         .long("input-file")
@@ -57,7 +54,7 @@ pub fn args() -> App<'static> {
                         .required(true),
                 )
                 .arg(
-                    Arg::with_name("output-file")
+                    Arg::new("output-file")
                         .about("Output file to write to")
                         .short('o')
                         .long("output-file")
@@ -66,7 +63,7 @@ pub fn args() -> App<'static> {
                         .default_value("cfg.dot"),
                 )
                 .arg(
-                    Arg::with_name("format")
+                    Arg::new("format")
                         .about("File format of the generated CFG")
                         .short('f')
                         .long("format")

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,11 @@ fn main() {
     }
 
     match matches.subcommand() {
-        ("disassemble", Some(disassemble_args)) => handle_error(|| {
+        Some(("disassemble", disassemble_args)) => handle_error(|| {
             let input = Path::new(disassemble_args.value_of("input-file").unwrap());
             disassemble_riscu(Path::new(input))
         }),
-        ("compile", Some(compiler_args)) => handle_error(|| -> Result<(), String> {
+        Some(("compile", compiler_args)) => handle_error(|| -> Result<(), String> {
             let compiler = compiler_args.value_of("compiler").unwrap();
 
             let input = Path::new(compiler_args.value_of("input-file").unwrap());
@@ -50,7 +50,7 @@ fn main() {
 
             Ok(())
         }),
-        ("cfg", Some(cfg_args)) => {
+        Some(("cfg", cfg_args)) => {
             handle_error(|| -> Result<(), String> {
                 let input = Path::new(cfg_args.value_of("input-file").unwrap());
                 let output = Path::new(cfg_args.value_of("output-file").unwrap());
@@ -72,7 +72,7 @@ fn main() {
                 Ok(())
             });
         }
-        ("smt", Some(_cfg_args)) => {
+        Some(("smt", _cfg_args)) => {
             handle_error(|| -> Result<(), String> {
                 use crate::formula_graph::{build_dataflow_graph, extract_candidate_path};
                 use petgraph::dot::Dot;


### PR DESCRIPTION
In order to use the new version of clap some adjustments are
necessary.

- Use the `clap::crate_authors!()` macro
- `clap::Arg::with_name()` -> `clap::Arg::new()`
- Adjust to `clap::App::get_matches()` new signature