### PR TITLE
Implement `SUB` instruction for the solver

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,11 @@
 use crate::{
     bitvec::BitVector,
+    boolector,
     candidate_path::create_candidate_paths,
     cfg,
     elf::ElfMetadata,
     formula_graph::{self, build_dataflow_graph, ExecutionResult, Formula},
-    smt, solver,
+    solver,
 };
 use riscv_decode::Instruction;
 use std::{collections::HashMap, path::Path};
@@ -47,7 +48,7 @@ fn execute_path(
             ExecutionResult::PathUnsat => None,
             ExecutionResult::PotentialError(root) => match with {
                 Backend::Monster => solver::solve(&formula, root),
-                Backend::Boolector => smt::smt(&formula, root),
+                Backend::Boolector => boolector::solve(&formula, root),
             },
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitvec;
+pub mod boolector;
 pub mod candidate_path;
 pub mod cfg;
 pub mod dead_code_elimination;
@@ -8,6 +9,5 @@ pub mod elf;
 pub mod engine;
 pub mod formula_graph;
 pub mod iterator;
-pub mod smt;
 pub mod solver;
 pub mod ternary;

--- a/symbolic/arithmetic_mul_add.c
+++ b/symbolic/arithmetic_mul_add.c
@@ -1,0 +1,18 @@
+uint64_t main() {
+  uint64_t  a;
+  uint64_t  b;
+  uint64_t  i;
+  uint64_t* x;
+
+  a = 43;
+  b = 2;
+  x = malloc(8);
+
+  read(0, x, 8);
+
+  a = a * *x;
+
+  b = b + a;
+
+  return b;
+}

--- a/symbolic/arithmetic_sub.c
+++ b/symbolic/arithmetic_sub.c
@@ -4,15 +4,13 @@ uint64_t main() {
   uint64_t  i;
   uint64_t* x;
 
-  a = 43;
-  b = 2;
+  a = 2;
+
   x = malloc(8);
 
   read(0, x, 8);
 
-  a = a * *x;
+  a = *x - a;
 
-  b = b + a; 
-
-  return b;
+  return a;
 }

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -3,9 +3,8 @@ use std::path::Path;
 
 mod common;
 
-#[test]
-fn execute_riscu_with_monster_solver() {
-    let result = common::compile(Path::new("symbolic/arithmetic.c")).unwrap();
+fn execute_riscu_with_monster_solver_name(name: &str) {
+    let result = common::compile(Path::new(name)).unwrap();
 
     let input = Path::new(&result);
 
@@ -13,8 +12,14 @@ fn execute_riscu_with_monster_solver() {
 
     assert!(
         result.is_ok(),
-        "can symbolically execute arithmetic.c without error"
+        format!("can symbolically execute '{}' without error", name)
     );
 
     assert!(std::fs::remove_file(input).is_ok());
+}
+
+#[test]
+fn execute_riscu_with_monster_solver() {
+    execute_riscu_with_monster_solver_name("symbolic/arithmetic_mul_add.c");
+    execute_riscu_with_monster_solver_name("symbolic/arithmetic_sub.c");
 }


### PR DESCRIPTION
- Rename `smt` module to `boolector` and fix a bug
- Implement `SUB` instruction for the solver