### PR TITLE
Fix bug and clippy warnings

### DIFF
--- a/src/candidate_path.rs
+++ b/src/candidate_path.rs
@@ -93,13 +93,7 @@ mod tests {
             .for_each(|(p, d)| {
                 let number_of_beqs = p
                     .into_iter()
-                    .filter(|i| {
-                        if let Instruction::Beq(_) = i {
-                            true
-                        } else {
-                            false
-                        }
-                    })
+                    .filter(|i| matches!(i, Instruction::Beq(_)))
                     .count();
                 let number_of_decisions = d.len();
 

--- a/src/formula_graph.rs
+++ b/src/formula_graph.rs
@@ -402,7 +402,7 @@ impl<'a> DataFlowGraphBuilder<'a> {
                 let to_add = 8 - (size % 8);
                 let words_read = (size + to_add) / 8;
 
-                for i in 0..words_read {
+                for i in 0..words_read - 1 {
                     let name = format!("read({}, {}, {})", 0, buffer, size);
                     let node = Node::Input(Input::new(name));
                     let node_idx = self.graph.add_node(node);

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -122,10 +122,7 @@ fn select(
     let (lhs, rhs) = parents(f, idx);
 
     fn is_constant(f: &Formula, n: NodeIndex) -> bool {
-        match f[n] {
-            Node::Constant(_) => true,
-            _ => false,
-        }
+        matches!(f[n], Node::Constant(_))
     }
 
     #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
- Classic OBOB
- Use `matches!` instead of `if` and `match` statements