### PR TITLE
perf: switch rarity simulation to segmented memory

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,7 +117,7 @@ pub fn args() -> App<'static, 'static> {
                         .long("memory")
                         .takes_value(true)
                         .value_name("NUMBER")
-                        .default_value(formatcp!("{}", symbolic_defaults::MEMORY_SIZE.0 / bytesize::MB))
+                        .default_value(formatcp!("{}", symbolic_defaults::MEMORY_SIZE.0 / bytesize::MIB))
                         .validator(is_valid_memory_size),
                 )
                 .arg(
@@ -147,7 +147,7 @@ pub fn args() -> App<'static, 'static> {
                         .long("memory")
                         .takes_value(true)
                         .value_name("NUMBER")
-                        .default_value(formatcp!("{}", rarity_defaults::MEMORY_SIZE.0 / bytesize::MB))
+                        .default_value(formatcp!("{}", rarity_defaults::MEMORY_SIZE.0 / bytesize::MIB))
                         .validator(is_valid_memory_size),
                 )
                 .arg(

--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -1,0 +1,116 @@
+use std::ops::{Index, IndexMut};
+
+#[derive(Debug, Clone)]
+pub struct VirtualMemory<T> {
+    memory_size: usize,
+    segment_mask: usize,
+    segment_shift: u32,
+    default: T,
+    data: Vec<Vec<T>>,
+}
+
+impl<T: Copy + Default> Index<usize> for VirtualMemory<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        let segment_index = index >> self.segment_shift;
+        let segment_offset = index & self.segment_mask;
+        if self.data[segment_index].is_empty() {
+            return &self.default;
+        }
+        Index::index(&self.data[segment_index], segment_offset)
+    }
+}
+
+impl<T: Copy + Default> IndexMut<usize> for VirtualMemory<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        let segment_index = index >> self.segment_shift;
+        let segment_offset = index & self.segment_mask;
+        if self.data[segment_index].is_empty() {
+            self.data[segment_index] = vec![T::default(); self.segment_mask + 1];
+        }
+        IndexMut::index_mut(&mut self.data[segment_index], segment_offset)
+    }
+}
+
+impl<T: Copy + Default> VirtualMemory<T> {
+    pub fn new(memory_size: usize, segment_size: usize) -> Self {
+        assert!(
+            memory_size % segment_size == 0,
+            "memory size must be multiple of segment size"
+        );
+        assert!(
+            segment_size.is_power_of_two(),
+            "segment size must be a power of two"
+        );
+        let segment_mask = segment_size - 1;
+        let segment_shift = segment_size.trailing_zeros();
+        let segments = memory_size / segment_size;
+        Self {
+            memory_size,
+            segment_mask,
+            segment_shift,
+            default: T::default(),
+            data: vec![[].to_vec(); segments],
+        }
+    }
+
+    /// Returns an iterator over values in mapped memory segments.
+    ///
+    /// Note that the iterator does not cover un-mapped segments (i.e. segments that have not been
+    /// written to before). This essentially skips over segments that would exclusively contain
+    /// [`T::default()`] values. It also means that iteration likely yields fewer elements than
+    /// calls of [`size()`] report.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.data.iter().filter(|x| !x.is_empty()).flatten()
+    }
+
+    pub fn size(&self) -> usize {
+        self.memory_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_default() {
+        let m = VirtualMemory::<i32>::new(32, 16);
+        assert_eq!(m[0], 0);
+        assert_eq!(m[15], 0);
+        assert_eq!(m[16], 0);
+        assert_eq!(m[31], 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn load_out_of_bounds() {
+        let m = VirtualMemory::<i32>::new(32, 16);
+        let _this_will_panic = m[32];
+    }
+
+    #[test]
+    fn store_value() {
+        let mut m = VirtualMemory::<i32>::new(32, 16);
+        assert_eq!(m[0], 0);
+        assert_eq!(m[1], 0);
+        m[0] = 7;
+        assert_eq!(m[0], 7);
+        assert_eq!(m[1], 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn store_out_of_bounds() {
+        let mut m = VirtualMemory::<i32>::new(32, 16);
+        m[32] = 7; // this will panic
+    }
+
+    #[test]
+    fn iter_values() {
+        let mut m = VirtualMemory::<i32>::new(8, 2);
+        m[0] = 23; // targets first segment
+        m[3] = 42; // targets second segment
+        assert_eq!(m.iter().copied().collect::<Vec<i32>>(), vec![23, 0, 0, 42]);
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,10 +1,12 @@
 pub mod bug;
+pub mod memory;
 pub mod rarity_simulation;
 pub mod symbolic_execution;
 pub mod symbolic_state;
 pub mod system;
 
 pub use bug::*;
+pub use memory::*;
 pub use rarity_simulation::*;
 pub use symbolic_execution::*;
 

--- a/src/engine/symbolic_execution.rs
+++ b/src/engine/symbolic_execution.rs
@@ -22,7 +22,7 @@ const INSTRUCTION_SIZE: u64 = INSTR_SIZE as u64;
 pub mod defaults {
     use super::*;
 
-    pub const MEMORY_SIZE: ByteSize = ByteSize(bytesize::MB);
+    pub const MEMORY_SIZE: ByteSize = ByteSize(bytesize::MIB);
     pub const MAX_EXECUTION_DEPTH: u64 = 1000;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
             let strategy = expect_arg::<ExplorationStrategyType>(&args, "strategy")?;
             let options = SymbolicExecutionOptions {
                 max_exection_depth: expect_arg(args, "max-execution-depth")?,
-                memory_size: ByteSize::mb(expect_arg(args, "memory")?),
+                memory_size: ByteSize::mib(expect_arg(args, "memory")?),
             };
 
             let program = load_object_file(&input)?;
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
             let input = expect_arg::<PathBuf>(args, "input-file")?;
 
             let options = RaritySimulationOptions {
-                memory_size: ByteSize::mb(expect_arg(args, "memory")?),
+                memory_size: ByteSize::mib(expect_arg(args, "memory")?),
                 amount_of_states: expect_arg(args, "states")?,
                 step_size: expect_arg(args, "step-size")?,
                 selection: expect_arg(args, "selection")?,


### PR DESCRIPTION
@ChristianMoesl: PTAL. Happy to pick another reviewer, just let me know.
@fischer-martin: Just FYI in case you are interested.

This introduces the engine::memory::Memory structure which splits the
linear memory into segments of fixed size. This will drastically reduce
overall memory consumption, state creation time, and scoring time. Note
that the engine execution time can increase because allocation is now
amortized as part of engine execution.

As part of this change we also switch to memory sizes specified at the
command line being interpreted as MiB instead of MB. This also ensures
memory sizes are multiples of the segment size.