### PR TITLE
ci: cleanup benches for automatic runs

### DIFF
--- a/benches/path_exploration.rs
+++ b/benches/path_exploration.rs
@@ -62,7 +62,8 @@ fn bench_shortes_paths_vs_coin_flip(c: &mut Criterion) {
                 max_exection_depth: match source.file_name().unwrap().to_str().unwrap() {
                     "two-level-nested-loop-1-35.c" => 230,
                     "recursive-fibonacci-1-10.c" => 300,
-                    _ => 1000000,
+                    "count_up_down-1.c" => 1000000,
+                    _ => 1000,
                 },
                 ..Default::default()
             };
@@ -97,6 +98,7 @@ fn bench_shortes_paths_vs_coin_flip(c: &mut Criterion) {
                 max_exection_depth: match source.file_name().unwrap().to_str().unwrap() {
                     "two-level-nested-loop-1-35.c" => 230,
                     "recursive-fibonacci-1-10.c" => 300,
+                    "count_up_down-1.c" => 1000000,
                     _ => 1000,
                 },
                 ..Default::default()

--- a/benches/rarity.rs
+++ b/benches/rarity.rs
@@ -7,19 +7,27 @@ use std::{
 };
 use utils::TestFileCompiler;
 
-const TEST_FILES: [&str; 3] = ["if-simple.c", "long-loop-fixed.c", "select-rare.c"];
+const TEST_FILES: [&str; 4] = [
+    "demonstration.c",
+    "if-simple.c",
+    "long-loop-fixed.c",
+    "select-rare.c",
+];
+
+const SAMPLE_SIZE: usize = 50;
+const WARM_UP_TIME: Duration = Duration::from_secs(1);
 
 lazy_static! {
     static ref COMPILER: TestFileCompiler = TestFileCompiler::new(&TEST_FILES);
 }
 
-criterion_group!(benches, bench_rarity,);
+criterion_group!(benches, bench_rarity);
 criterion_main!(benches);
 
 fn bench_rarity(c: &mut Criterion) {
     let mut group = c.benchmark_group("Rarity");
 
-    group.sample_size(50).warm_up_time(Duration::from_secs(1));
+    group.sample_size(SAMPLE_SIZE).warm_up_time(WARM_UP_TIME);
 
     COMPILER.objects().iter().for_each(|object| {
         let id = object.file_name().unwrap().to_str().unwrap();


### PR DESCRIPTION
This just cleans up the existing benchmark suites to make them finish
in reasonable amount of time in preparation for our automatic benchmark
workflows. Both `engine.rs` and `rarity.rs` are now based on the same
set of test files as well.