### PR TITLE
fix: invertibility condition for SLTU (when `t != 0`)

### DIFF
--- a/examples/test-sltu-2.c
+++ b/examples/test-sltu-2.c
@@ -1,0 +1,21 @@
+uint64_t main() {
+  uint64_t  a;
+  uint64_t* x;
+
+  x = malloc(8);
+
+  *x = 0;
+
+  read(0, x, 1);
+
+  a = *x - 42;
+
+  if (a < 0)
+    return 0;
+  if (a > 18446744073709551615)
+    return 0;
+  if (a == 18446744073709551615)
+    return 1;
+
+  return 0;
+}

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use utils::{compile_riscu, init, with_temp_dir};
 
-const TEST_FILES: [&str; 20] = [
+const TEST_FILES: [&str; 21] = [
     "arithmetic.c",
     "echo-line.c",
     "if-else.c", // needs timeout
@@ -22,6 +22,7 @@ const TEST_FILES: [&str; 20] = [
     "simple-assignment-1-35.c",
     "test-remu.c",
     "test-sltu.c",
+    "test-sltu-2.c",
     //"memory-access-1-35.c",
     "memory-invalid-read.c",
     "memory-invalid-write.c",
@@ -184,6 +185,7 @@ fn execute_riscu<S: Solver>(source: PathBuf, object: PathBuf, solver: &S) {
                 ("simple-assignment-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
                 ("test-remu.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
                 ("test-sltu.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
+                ("test-sltu-2.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
                 //("memory-access-1-35.c", Bug::
                 ("memory-invalid-read.c", SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }) |
                 ("memory-invalid-write.c", SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }) |


### PR DESCRIPTION
This fixes the bogus assumption that `t != BitVector(1)` implies that
`t == BitVector(0)`, which does not hold in our engine since the target
value `t` can be any arbitrary 64-bit vector. Determining whether such
target values make sense in general is outside the scope of this change.