### PR TITLE
chore: update Rust toolchain to v1.52.0 (#119)

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -2,9 +2,6 @@
 
 set -e
 
-# make clippy check all rust files again (bug in clippy)
-find . -name '*.rs' | xargs touch
-
 echo '+cargo clippy --all-features --all-targets -- -D warnings'
 cargo clippy --all-features --all-targets -- -D warnings
 echo '+cargo fmt -- --check'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust 1.50.0
+      - name: Install Rust 1.52.0
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.50.0
+          toolchain: 1.52.0
           override: true
 
       - name: Build Benchmarks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toolchain: [1.50.0]
+        toolchain: [1.52.0]
         os: [ubuntu-20.04, macos-10.15, windows-2019]
         include:
           - platform: linux
@@ -114,7 +114,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.50.0
+          toolchain: 1.52.0
           override: true
 
       - name: Install Semantic Release for Rust

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toolchain: [1.50.0]
+        toolchain: [1.52.0]
         os: [ubuntu-20.04, macos-10.15, windows-2019]
         experimental: [false]
         include:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crate](https://img.shields.io/crates/v/monster-rs.svg)](https://crates.io/crates/monster-rs)
 [![API](https://docs.rs/monster-rs/badge.svg)](https://docs.rs/monster-rs)
 ![Experimental Status](https://img.shields.io/badge/status-experimental-yellow.svg)
-![Rust Version](https://img.shields.io/badge/Rust-v1.50.0-yellow)
+![Rust Version](https://img.shields.io/badge/Rust-v1.52.0-yellow)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-brightgreen)
 [![Lines of Code](https://img.shields.io/tokei/lines/github/cksystemsgroup/monster)](https://github.com/cksystemsgroup/monster)
 [![License](https://img.shields.io/crates/l/monster-rs)](https://github.com/cksystemsgroup/monster/blob/master/LICENSE)
@@ -41,7 +41,7 @@ Just make sure you build for one of these targets:
  - x86_64-apple-darwin
  - x86_64-pc-windows-msvc
 
-1. Bootstrap Rust v1.50.0 from [https://rustup.rs](https://rustup.rs) and make sure:
+1. Bootstrap Rust v1.52.0 from [https://rustup.rs](https://rustup.rs) and make sure:
  - you install it with one of the supported host triples and 
  - add it to your path
 2. Install Rustfmt (formatter) and Clippy (linter)

--- a/src/disassemble.rs
+++ b/src/disassemble.rs
@@ -43,9 +43,9 @@ impl Disassembly {
     }
 }
 
-impl Into<DecodedProgram> for Disassembly {
-    fn into(self) -> DecodedProgram {
-        self.decoded
+impl From<Disassembly> for DecodedProgram {
+    fn from(disassembly: Disassembly) -> DecodedProgram {
+        disassembly.decoded
     }
 }
 

--- a/src/path_exploration/shortest_path.rs
+++ b/src/path_exploration/shortest_path.rs
@@ -108,13 +108,7 @@ pub fn compute_distances(cfg: &ControlFlowGraph) -> HashMap<NodeIndex, u64> {
 
         let distances_for_idx = unrolled
             .node_indices()
-            .filter_map(|i| {
-                if let Some(d) = distances.get(&i) {
-                    Some((unrolled[i], *d))
-                } else {
-                    None
-                }
-            })
+            .filter_map(|i| distances.get(&i).map(|d| (unrolled[i], *d)))
             .into_group_map();
 
         distances_for_idx

--- a/src/solver/bitvec.rs
+++ b/src/solver/bitvec.rs
@@ -24,10 +24,8 @@ impl BitVector {
     }
 
     pub fn modinverse(&self) -> Option<BitVector> {
-        match modinverse::modinverse((self.0 as u128) as i128, 2_i128.pow(64)) {
-            Some(res) => Some(BitVector(res as u64)),
-            None => None,
-        }
+        modinverse::modinverse((self.0 as u128) as i128, 2_i128.pow(64))
+            .map(|res| BitVector(res as u64))
     }
 
     pub fn addo(&self, t: BitVector) -> bool {

--- a/src/solver/boolector.rs
+++ b/src/solver/boolector.rs
@@ -43,18 +43,16 @@ impl Solver for Boolector {
                 let assignments = formula
                     .symbol_ids()
                     .filter_map(|i| {
-                        if let Some(bv) = bvs.get(&i) {
-                            Some((
+                        bvs.get(&i).map(|bv| {
+                            (
                                 i,
                                 BitVector(
                                     bv.get_a_solution()
                                         .as_u64()
                                         .expect("BV always fits in 64 bits for our machine"),
                                 ),
-                            ))
-                        } else {
-                            None
-                        }
+                            )
+                        })
                     })
                     .collect();
 

--- a/src/solver/z3.rs
+++ b/src/solver/z3.rs
@@ -49,10 +49,7 @@ impl Solver for Z3 {
                 Ok(Some(
                     formula
                         .symbol_ids()
-                        .filter_map(|i| match bv_for_node_idx(i, translation, &model) {
-                            Some(bv) => Some((i, bv)),
-                            None => None,
-                        })
+                        .filter_map(|i| bv_for_node_idx(i, translation, &model).map(|bv| (i, bv)))
                         .collect(),
                 ))
             }

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -82,10 +82,8 @@ fn execute_with_different_memory_sizes() {
 
                 assert!(
                     result.is_ok(),
-                    format!(
-                        "can symbolically execute '{}' without error",
-                        source.to_str().unwrap()
-                    )
+                    "can symbolically execute '{}' without error",
+                    source.to_str().unwrap()
                 );
             });
         });
@@ -159,17 +157,16 @@ fn execute_riscu<S: Solver>(source: PathBuf, object: PathBuf, solver: &S) {
 
     assert!(
         result.is_ok(),
-        format!(
-            "can symbolically execute '{}' without error",
-            source.to_str().unwrap()
-        )
+        "can symbolically execute '{}' without error",
+        source.to_str().unwrap()
     );
 
     let possible_bug = result.unwrap();
 
     assert!(
         possible_bug.is_some(),
-        format!("found a bug in '{}'", source.to_str().unwrap())
+        "found a bug in '{}'",
+        source.to_str().unwrap()
     );
 
     let bug = possible_bug.unwrap();


### PR DESCRIPTION
fixes #119

Updated toolchain and fixed new linter errors.