### PR TITLE
feat: handle exit points with unknown satisfiability

### DIFF
--- a/benches/engine.rs
+++ b/benches/engine.rs
@@ -130,6 +130,7 @@ fn execute_symbolically<S: Solver, P: AsRef<Path>>(object_path: P) {
     let options = SymbolicExecutionOptions {
         max_exection_depth: 5000000,
         memory_size: ByteSize(400000),
+        ..Default::default()
     };
     let solver = S::default();
     let strategy = ShortestPathStrategy::compute_for(&program).unwrap();

--- a/src/engine/bug.rs
+++ b/src/engine/bug.rs
@@ -28,7 +28,7 @@ pub enum Bug<Info: BugInfo> {
 
     ExitCodeGreaterZero {
         info: Info,
-        exit_code: u64,
+        exit_code: Info::Value,
         address: u64,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,8 @@ where
     Strategy: path_exploration::ExplorationStrategy,
     Solver: solver::Solver,
 {
-    let mut engine = SymbolicExecutionEngine::new(&program, &options, strategy, solver);
-
-    engine
-        .search_for_bugs()
+    SymbolicExecutionEngine::new(&options, strategy, solver)
+        .search_for_bugs(&program)
         .map_err(MonsterError::SymbolicExecution)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,11 @@ use monster::{
     },
     rarity_simulate_elf_with,
     solver::{
-        self, SmtType,
+        self,
         SolverType::{self, Monster},
     },
-    symbolically_execute_elf_with, RaritySimulationOptions, SymbolicExecutionOptions,
+    symbolically_execute_elf_with, RaritySimulationOptions, SmtGenerationOptions,
+    SymbolicExecutionOptions,
 };
 use riscu::load_object_file;
 use std::{
@@ -71,10 +72,10 @@ fn main() -> Result<()> {
             let input = expect_arg::<PathBuf>(&args, "input-file")?;
             let output = expect_optional_arg::<PathBuf>(&args, "output-file")?;
             let strategy = expect_arg::<ExplorationStrategyType>(&args, "strategy")?;
-            let smt_type = expect_arg::<SmtType>(&args, "smt-type")?;
-            let options = SymbolicExecutionOptions {
-                max_exection_depth: expect_arg(args, "max-execution-depth")?,
+            let options = SmtGenerationOptions {
+                max_execution_depth: expect_arg(args, "max-execution-depth")?,
                 memory_size: ByteSize::mib(expect_arg(args, "memory")?),
+                smt_type: expect_arg(&args, "smt-type")?,
             };
 
             let program = load_object_file(&input)?;
@@ -84,18 +85,18 @@ fn main() -> Result<()> {
                     let strategy = ShortestPathStrategy::compute_for(&program)?;
 
                     if let Some(file) = output {
-                        generate_smt_to_file(&input, &file, &options, &strategy, smt_type)
+                        generate_smt_to_file(&input, &file, &options, &strategy)
                     } else {
-                        generate_smt(&input, stdout(), &options, &strategy, smt_type)
+                        generate_smt(&input, stdout(), &options, &strategy)
                     }
                 }
                 CoinFlip => {
                     let strategy = CoinFlipStrategy::default();
 
                     if let Some(file) = output {
-                        generate_smt_to_file(&input, &file, &options, &strategy, smt_type)
+                        generate_smt_to_file(&input, &file, &options, &strategy)
                     } else {
-                        generate_smt(&input, stdout(), &options, &strategy, smt_type)
+                        generate_smt(&input, stdout(), &options, &strategy)
                     }
                 }
             }
@@ -115,6 +116,7 @@ fn main() -> Result<()> {
             let options = SymbolicExecutionOptions {
                 max_exection_depth: expect_arg(args, "max-execution-depth")?,
                 memory_size: ByteSize::mib(expect_arg(args, "memory")?),
+                ..Default::default()
             };
 
             let program = load_object_file(&input)?;

--- a/src/solver/smt.rs
+++ b/src/solver/smt.rs
@@ -2,6 +2,7 @@ use super::{
     Assignment, BVOperator, BitVector, Formula, FormulaVisitor, SmtSolver, Solver, SolverError,
     SymbolId,
 };
+use bytesize::ByteSize;
 use std::{
     collections::HashMap,
     io::{stdout, BufWriter, Write},
@@ -17,6 +18,30 @@ pub enum SmtType {
     Boolector,
     #[cfg(feature = "z3")]
     Z3,
+}
+
+pub struct SmtGenerationOptions {
+    pub smt_type: SmtType,
+    pub memory_size: ByteSize,
+    pub max_execution_depth: u64,
+}
+
+pub mod defaults {
+    use super::*;
+
+    pub const MEMORY_SIZE: ByteSize = ByteSize(bytesize::MIB);
+    pub const MAX_EXECUTION_DEPTH: u64 = 1000;
+    pub const SMT_TYPE: SmtType = SmtType::Generic;
+}
+
+impl Default for SmtGenerationOptions {
+    fn default() -> Self {
+        Self {
+            memory_size: defaults::MEMORY_SIZE,
+            max_execution_depth: defaults::MAX_EXECUTION_DEPTH,
+            smt_type: defaults::SMT_TYPE,
+        }
+    }
 }
 
 pub struct SmtWriter {

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -76,6 +76,7 @@ fn execute_with_different_memory_sizes() {
                 let options = SymbolicExecutionOptions {
                     max_exection_depth: 200,
                     memory_size: ByteSize::mb(*size),
+                    ..Default::default()
                 };
 
                 let result = execute_default_with(&object, &options);
@@ -102,8 +103,8 @@ fn execute_engine_for_endless_loops() {
             };
 
             assert!(
-                execute_default_with(object, &options).is_err(),
-                "has to error with depth error"
+                execute_default_with(object, &options).is_ok(),
+                "no bug can be found with execution depth of 5"
             );
         });
     });

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use utils::{compile_riscu, init, with_temp_dir};
 
-const TEST_FILES: [&str; 21] = [
+const TEST_FILES: [&str; 22] = [
     "arithmetic.c",
     "echo-line.c",
     "if-else.c", // needs timeout
@@ -23,7 +23,7 @@ const TEST_FILES: [&str; 21] = [
     "test-remu.c",
     "test-sltu.c",
     "test-sltu-2.c",
-    //"memory-access-1-35.c",
+    "memory-access-1-35.c",
     "memory-invalid-read.c",
     "memory-invalid-write.c",
     "memory-uninitialized-write.c",
@@ -175,28 +175,73 @@ fn execute_riscu<S: Solver>(source: PathBuf, object: PathBuf, solver: &S) {
     assert!(
         matches!(
             (file_name, bug.clone()),
-            ("arithmetic.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("echo-line.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("invalid-memory-access-2-35.c", SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }) |
-                ("if-else.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("division-by-zero-3-35.c", SymbolicExecutionBug::DivisionByZero { .. }) |
-                ("simple-assignment-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("test-remu.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("test-sltu.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("test-sltu-2.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                //("memory-access-1-35.c", Bug::
-                ("memory-invalid-read.c", SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }) |
-                ("memory-invalid-write.c", SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }) |
-                ("memory-uninitialized-write.c", SymbolicExecutionBug::AccessToUnitializedMemory { .. }) |
-                ("nested-if-else-reverse-1-35", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("nested-recursion-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("recursive-ackermann-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("recursive-factorial-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("recursive-fibonacci-1-10.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("simple-if-else-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("simple-increasing-loop-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("two-level-nested-loop-1-35.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. }) |
-                ("multiple-read.c", SymbolicExecutionBug::ExitCodeGreaterZero { .. })
+            (
+                "arithmetic.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "echo-line.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "invalid-memory-access-2-35.c",
+                SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }
+            ) | (
+                "if-else.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "division-by-zero-3-35.c",
+                SymbolicExecutionBug::DivisionByZero { .. }
+            ) | (
+                "simple-assignment-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "test-remu.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "test-sltu.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "test-sltu-2.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "memory-access-1-35.c",
+                SymbolicExecutionBug::AccessToUnitializedMemory { .. }
+            ) | (
+                "memory-invalid-read.c",
+                SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }
+            ) | (
+                "memory-invalid-write.c",
+                SymbolicExecutionBug::AccessToOutOfRangeAddress { .. }
+            ) | (
+                "memory-uninitialized-write.c",
+                SymbolicExecutionBug::AccessToUnitializedMemory { .. }
+            ) | (
+                "nested-if-else-reverse-1-35",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "nested-recursion-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "recursive-ackermann-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "recursive-factorial-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "recursive-fibonacci-1-10.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "simple-if-else-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "simple-increasing-loop-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "two-level-nested-loop-1-35.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            ) | (
+                "multiple-read.c",
+                SymbolicExecutionBug::ExitCodeGreaterZero { .. }
+            )
         ),
         "found right bug type (actual: {}) for {}",
         bug,

--- a/tests/smt.rs
+++ b/tests/smt.rs
@@ -2,29 +2,26 @@ use lazy_static::lazy_static;
 use log::info;
 use monster::{
     self, generate_smt_to_file, load_elf, path_exploration::ShortestPathStrategy, solver::SmtType,
-    SymbolicExecutionOptions,
+    SmtGenerationOptions,
 };
 use std::{path::PathBuf, sync::Arc};
 use tempfile::TempDir;
 use utils::{init, with_temp_dir, TestFileCompiler};
 
-const TEST_FILES: [&str; 19] = [
+const TEST_FILES: [&str; 22] = [
     "echo-line.c",
     "division-by-zero-3-35.c",
     "simple-assignment-1-35.c",
-    "if-else.c", // needs timeout
+    "if-else.c",
     "arithmetic.c",
     "test-remu.c",
     "test-sltu.c",
     "test-sltu-2.c",
     "simple-if-else-1-35.c",
     "invalid-memory-access-2-35.c",
-    //
-    // TODO: Fix uncoditional exits in combination with external solver first:
-    // "memory-invalid-read.c",
-    // "memory-invalid-write.c",
-    // "memory-access-1-35.c",
-    //
+    "memory-invalid-read.c",
+    "memory-invalid-write.c",
+    "memory-access-1-35.c",
     "memory-uninitialized-write.c",
     "nested-if-else-reverse-1-35",
     "nested-recursion-1-35.c",
@@ -200,9 +197,11 @@ fn generate_smt(
     let result = generate_smt_to_file(
         &files.1,
         &output_path,
-        &SymbolicExecutionOptions::default(),
+        &SmtGenerationOptions {
+            smt_type,
+            ..Default::default()
+        },
         &strategy,
-        smt_type,
     );
 
     assert!(


### PR DESCRIPTION
disable optimistic search space pruning, when generating
SMT-lib files.
fix a bug, which crashes the engine, when satisfiability is unknown.