### PR TITLE
perf: switch partial reads to use bitwise AND

### DIFF
--- a/examples/test-sltu-3.c
+++ b/examples/test-sltu-3.c
@@ -1,0 +1,19 @@
+uint64_t main() {
+  uint64_t  a;
+  uint64_t* x;
+
+  x = malloc(8);
+
+  *x = 0;
+
+  read(0, x, 4);
+
+  a = *x - 48;
+
+  if (a < 9)
+    return 0;
+  if (a == 9)
+    return 1;
+
+  return 0;
+}


### PR DESCRIPTION
This switches partial `read` syscalls (i.e. those that don't read
multiples of 8 bytes) to use bitwise AND operators instead of MUL and
DIV when combining values bytewise. The goal is to produce a simpler
formula for the solver. Note that incomplete solvers in particular have
a hard time solving "t = x * (2^N) / (2^N)" for example.