### PR TITLE
fix: profiler no longer miscounts solver times.

### DIFF
--- a/src/engine/symbolic_execution.rs
+++ b/src/engine/symbolic_execution.rs
@@ -934,6 +934,8 @@ where
         let amount_of_file_descriptors_snapshot = self.amount_of_file_descriptors;
         let profiler_snapshot = self.profiler.clone();
 
+        self.profiler = Profiler::new();
+
         let result = f(self);
         let profiler = self.profiler.clone();
 
@@ -986,7 +988,6 @@ where
                         next_pc,
                     );
 
-                    this.profiler = Profiler::new();
                     this.profiler.took_beq_branch(decision);
 
                     this.pc = next_pc;


### PR DESCRIPTION
This moves the allocation time of a new profiler when forking states to
an earlier position (into the `with_snapshot` method). This prevents the
solver time for deciding whether a branch is reachable or not from being
lost. Furthermore, we also need to allocate a new profiler when a branch
is skipped, to avoid falsely double-counting the stale profiler.