### PR TITLE
feat(modeler): add bounds checks for memory accesses

### DIFF
--- a/src/modeler/memory.rs
+++ b/src/modeler/memory.rs
@@ -46,19 +46,12 @@ struct MemoryReplacer {
     virtual_addresses: Vec<u64>,
 }
 
-const MAX_HEAP_SIZE: u64 = 8 * size_of::<u64>() as u64; // TODO: Make this configurable.
-const MAX_STACK_SIZE: u64 = 16 * size_of::<u64>() as u64; // TODO: Make this configurable.
-
 fn enumerate_virtual_addresses(model: &Model) -> Vec<u64> {
-    // TODO: The range for the data segment is missing.
-    let heap_start = model.program_break;
-    let heap_end = model.program_break + MAX_HEAP_SIZE;
-    let heap_range = heap_start..heap_end;
-    let stack_start = model.memory_size - MAX_STACK_SIZE;
-    let stack_end = model.memory_size;
-    let stack_range = stack_start..stack_end;
-    heap_range
-        .chain(stack_range)
+    model
+        .data_range
+        .clone()
+        .chain(model.heap_range.clone())
+        .chain(model.stack_range.clone())
         .step_by(size_of::<u64>())
         .collect()
 }

--- a/src/modeler/mod.rs
+++ b/src/modeler/mod.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::LinkedList;
 use std::hash::{Hash, Hasher};
+use std::ops::Range;
 use std::rc::Rc;
 
 //
@@ -135,8 +136,10 @@ pub struct Model {
     pub sequentials: Vec<NodeRef>,
     pub bad_states_initial: Vec<NodeRef>,
     pub bad_states_sequential: Vec<NodeRef>,
+    pub data_range: Range<u64>,
+    pub heap_range: Range<u64>,
+    pub stack_range: Range<u64>,
     pub memory_size: u64,
-    pub program_break: u64,
 }
 
 #[derive(Debug)]
@@ -147,6 +150,13 @@ pub struct HashableNodeRef {
 #[rustfmt::skip]
 pub fn print_model(model: &Model) {
     println!("; cksystemsgroup.github.io/monster\n");
+    println!(
+        "; {} total virtual memory, {} data, {} max heap, {} max stack\n",
+        bytesize::ByteSize(model.memory_size).to_string_as(true),
+        bytesize::ByteSize(model.data_range.size_hint().0 as u64),
+        bytesize::ByteSize(model.heap_range.size_hint().0 as u64),
+        bytesize::ByteSize(model.stack_range.size_hint().0 as u64)
+    );
     println!("1 sort bitvec 1 ; Boolean");
     println!("2 sort bitvec 64 ; 64-bit machine word");
     println!("3 sort array 2 2 ; 64-bit virtual memory");


### PR DESCRIPTION
This adds proper bounds checks for all three segments (data, heap, and stack) while building the model. Note that `malloc` doesn't work properly yet, because the `brk` system call is not implemented yet. Also the data segment is not correctly initialized yet. I will do those two things next.

/cc @smml1996 